### PR TITLE
Fixed naming issue: replaced 'period' with 'duration'

### DIFF
--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,12 +1,12 @@
 export const Education = ({
   degree,
   school,
-  period,
+  duration,
   details,
 }: {
   degree: string;
   school: string;
-  period: string;
+  duration: string;
   details: string;
 }) => {
   return (
@@ -16,7 +16,7 @@ export const Education = ({
           <h3 className="font-bold text-[#374151]">{degree}</h3>
           <p className="text-gray-600">{school}</p>
         </div>
-        <span className="text-gray-500 text-sm">{period}</span>
+        <span className="text-gray-500 text-sm">{duration}</span>
       </div>
       <p className="text-gray-600 text-sm">{details}</p>
     </div>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,13 +1,13 @@
 export const WorkExperience = ({
   title,
   company,
-  period,
+  duration,
   location,
   responsibilities,
 }: {
   title: string;
   company: string;
-  period: string;
+  duration: string;
   location: string;
   responsibilities: string[];
 }) => {
@@ -20,7 +20,7 @@ export const WorkExperience = ({
             {company} {location}
           </p>
         </div>
-        <span className="text-gray-500 text-sm">{period}</span>
+        <span className="text-gray-500 text-sm">{duration}</span>
       </div>
       <ul className="list-disc list-inside text-gray-600 space-y-1 text-sm">
         {responsibilities.map((item, index) => (

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -24,7 +24,7 @@ export const MainContent = () => {
         <WorkExperience
           title={t("workExperience.holoXR.title")}
           company={t("workExperience.holoXR.company")}
-          period={t("workExperience.holoXR.period")}
+          duration={t("workExperience.holoXR.duration")}
           location={t("workExperience.holoXR.location")}
           responsibilities={[
             t("workExperience.holoXR.responsibilities.0"),
@@ -37,7 +37,7 @@ export const MainContent = () => {
         <WorkExperience
           title={t("workExperience.sevenSuite.title")}
           company={t("workExperience.sevenSuite.company")}
-          period={t("workExperience.sevenSuite.period")}
+          duration={t("workExperience.sevenSuite.duration")}
           location={t("workExperience.sevenSuite.location")}
           responsibilities={[
             t("workExperience.sevenSuite.responsibilities.0"),
@@ -50,7 +50,7 @@ export const MainContent = () => {
         <WorkExperience
           title={t("workExperience.norkut.title")}
           company={t("workExperience.norkut.company")}
-          period={t("workExperience.norkut.period")}
+          duration={t("workExperience.norkut.duration")}
           location={t("workExperience.norkut.location")}
           responsibilities={[
             t("workExperience.norkut.responsibilities.0"),
@@ -63,7 +63,7 @@ export const MainContent = () => {
         <WorkExperience
           title={t("workExperience.nanotecks.title")}
           company={t("workExperience.nanotecks.company")}
-          period={t("workExperience.nanotecks.period")}
+          duration={t("workExperience.nanotecks.duration")}
           location={t("workExperience.nanotecks.location")}
           responsibilities={[
             t("workExperience.nanotecks.responsibilities.0"),
@@ -83,14 +83,14 @@ export const MainContent = () => {
           <Education
             degree={t("education.udo.title")}
             school={t("education.udo.institution")}
-            period={t("education.udo.duration")}
+            duration={t("education.udo.duration")}
             details={t("education.udo.details")}
           />
 
           <Education
             degree={t("education.highSchool.title")}
             school={t("education.highSchool.institution")}
-            period={t("education.highSchool.duration")}
+            duration={t("education.highSchool.duration")}
             details={t("education.highSchool.details")}
           />
         </div>


### PR DESCRIPTION
Fixed bug where the word 'period' was confused with the word 'duration', causing the duration of the work experience no appear in the web.